### PR TITLE
Implement Encrypted Image Uploads (Up1)

### DIFF
--- a/.travis/linux_install.sh
+++ b/.travis/linux_install.sh
@@ -4,11 +4,11 @@ set -e
 
 if [[ "${EXTEN}" == "other" ]]; then
 	# Compile-time
-	travis_retry sudo apt install -y gcc g++ build-essential qt5-default qt5-qmake qttools5-dev-tools
+	travis_retry sudo apt install -y gcc g++ build-essential qt5-default qt5-qmake qttools5-dev-tools openssl
 	# Run-time
 	travis_retry sudo apt install -y libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5-dev
 	# Optional
-	travis_retry sudo apt install -y openssl ca-certificates
+	travis_retry sudo apt install -y ca-certificates
 	# Install fcitx-frontend-qt5
 	travis_retry sudo apt install -y fcitx-frontend-qt5
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 - Easy to use.
 - In-app screenshot edition.
 - DBus interface.
-- Upload to Imgur.
+- Upload to Imgur or Up1 (Riseup).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ To build the application in your system, you'll need to install the dependencies
 - Qt >= 5.3
   + Development tools
 - GCC >= 4.9.2
+- OpenSSL
 
 #### Run-time
 
@@ -259,46 +260,45 @@ To build the application in your system, you'll need to install the dependencies
 #### Optional
 
 - Git
-- OpenSSL
 - CA Certificates
 
 #### Debian
 
 ```shell
 # Compile-time
-apt install g++ build-essential qt5-default qt5-qmake qttools5-dev-tools
+apt install g++ build-essential qt5-default qt5-qmake qttools5-dev-tools openssl
 
 # Run-time
 apt install libqt5dbus5 libqt5network5 libqt5core5a libqt5widgets5 libqt5gui5 libqt5svg5-dev
 
 # Optional
-apt install git openssl ca-certificates
+apt install git ca-certificates
 ```
 
 #### Fedora
 
 ```shell
 # Compile-time
-dnf install gcc-c++ qt5-devel qt5-qtbase-devel qt5-linguist
+dnf install gcc-c++ qt5-devel qt5-qtbase-devel qt5-linguist openssl
 
 # Run-time
 dnf install qt5-qtbase qt5-qtsvg-devel
 
 # Optional
-dnf install git openssl ca-certificates
+dnf install git ca-certificates
 ```
 
 #### Arch
 
 ```shell
 # Compile-time
-pacman -S base-devel git qt5-base qt5-tools
+pacman -S base-devel git qt5-base qt5-tools openssl
 
 # Run-time
 pacman -S qt5-svg
 
 # Optional
-pacman -S openssl ca-certificates
+pacman -S ca-certificates
 ```
 
 ### Build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,8 @@ environment:
     VSVER: 14
 
     matrix:
-        - QT: C:\Qt\5.9\msvc2015_64
+        - QT: C:\Qt\5.12\msvc2015_64
           PLATFORM: amd64
-        - QT: C:\Qt\5.9\msvc2015
-          PLATFORM: x86
 init:
     - ps: |
         $version = new-object System.Version $env:APPVEYOR_BUILD_VERSION
@@ -25,6 +23,8 @@ init:
 
 # scripts that run after cloning repository
 install:
+    - ps: Start-FileDownload 'https://slproweb.com/download/Win64OpenSSL-1_1_1d.exe'
+    - ps: Start-Process "Win64OpenSSL-1_1_1d.exe" -ArgumentList "/silent /verysilent /sp- /suppressmsgboxes /dir=C:\OpenSSL-Win64" -Wait
     - set PATH=%QT%\bin\;C:\Qt\Tools\QtCreator\bin\;C:\Qt\QtIFW3.0.1\bin\;%PATH%
 
 # scripts that run before build
@@ -34,17 +34,15 @@ before_build:
     - qmake --version
     - mkdir build
     - cd build
-    - if "%PLATFORM%" EQU "X64" (qmake -r -spec win32-msvc CONFIG+=x86_64 CONFIG-=debug CONFIG+=release ../flameshot.pro)
-    - if "%PLATFORM%" EQU "x86" (qmake -r -spec win32-msvc CONFIG+=Win32 CONFIG-=debug CONFIG+=release ../flameshot.pro)
+    - qmake -r -spec win32-msvc CONFIG+=x86_64 CONFIG-=debug CONFIG+=release ../flameshot.pro
 
 # custom build scripts
 build_script:
+    - set CL=/MP
     - nmake
 
 # scripts that run after build
 after_build:
-    # Clone OpenSSL DLLs
-    - git clone https://github.com/tamlok/openssl-utils.git openssl-utils.git
     - mkdir distrib\flameshot
     - windeployqt.exe --dir .\distrib\flameshot %APPVEYOR_BUILD_FOLDER%\build\release\flameshot.exe
     - copy "%APPVEYOR_BUILD_FOLDER%\build\release\flameshot.exe" "distrib\flameshot\flameshot.exe"
@@ -57,9 +55,8 @@ after_build:
     - copy "%APPVEYOR_BUILD_FOLDER%\build\translations\Internationalization_*.qm" "distrib\flameshot\translations"
     # Delete translations\qt_*.qm
     - del /F /Q "distrib\flameshot\translations\qt_*.qm"
-    # Copy OpenSSL DLLs
-    - if "%PLATFORM%" EQU "X64" (xcopy "openssl-utils.git\win64\*.dll" "distrib\flameshot")
-    - if "%PLATFORM%" EQU "x86" (xcopy "openssl-utils.git\win32\*.dll" "distrib\flameshot")
+    # Copy OpenSSL DLL
+    - xcopy "C:\OpenSSL-Win64\*.dll" "distrib\flameshot"
     - cd distrib
     - 7z a flameshot_%flameshot_version%_win_%PLATFORM%.zip flameshot
     - appveyor-retry curl --upload-file ./flameshot_%flameshot_version%_win_%PLATFORM%.zip https://transfer.sh/flameshot_%flameshot_version%_win_%PLATFORM%.zip

--- a/debian/control
+++ b/debian/control
@@ -19,11 +19,11 @@ Package: flameshot
 Architecture: any
 Depends:
  libqt5svg5,
+ openssl,
  ${shlibs:Depends},
  ${misc:Depends},
 Suggests:
  ca-certificates,
- openssl,
 Description: Powerful yet simple-to-use screenshot software
  Flameshot is a powerful yet simple-to-use screenshot software.
  Notable features include customizable appearance, in-app screenshot editing,

--- a/flameshot.pro
+++ b/flameshot.pro
@@ -16,6 +16,7 @@ QT  += core gui widgets network svg
 
 unix:!macx {
     QT  += dbus
+    LIBS += -lcrypto
 }
 
 CONFIG += c++11 link_pkgconfig
@@ -232,6 +233,16 @@ win32 {
     SOURCES += src/core/globalshortcutfilter.cpp
 
     HEADERS  += src/core/globalshortcutfilter.h
+
+    !contains(QMAKE_TARGET.arch, x86_64) {
+        INCLUDEPATH += C:/OpenSSL-Win32/include
+        LIBS += -L"C:/OpenSSL-Win32/lib" -llibcrypto
+        LIBS += -L"C:/OpenSSL-Win32/lib" -llibssl
+    } else {
+        INCLUDEPATH += C:/OpenSSL-Win64/include
+        LIBS += -L"C:/OpenSSL-Win64/lib" -llibcrypto
+        LIBS += -L"C:/OpenSSL-Win64/lib" -llibssl
+    }
 }
 
 RESOURCES += \

--- a/flameshot.pro
+++ b/flameshot.pro
@@ -97,6 +97,7 @@ SOURCES += src/main.cpp \
     src/tools/copy/copytool.cpp \
     src/tools/exit/exittool.cpp \
     src/tools/imgur/imguruploadertool.cpp \
+    src/tools/up1/up1uploadertool.cpp \
     src/tools/line/linetool.cpp \
     src/tools/marker/markertool.cpp \
     src/tools/move/movetool.cpp \
@@ -114,6 +115,7 @@ SOURCES += src/main.cpp \
     src/cli/commandargument.cpp \
     src/utils/screenshotsaver.cpp \
     src/tools/imgur/imguruploader.cpp \
+    src/tools/up1/up1uploader.cpp \
     src/widgets/loadspinner.cpp \
     src/widgets/imagelabel.cpp \
     src/widgets/notificationwidget.cpp \
@@ -171,6 +173,7 @@ HEADERS  += src/widgets/capture/buttonhandler.h \
     src/tools/copy/copytool.h \
     src/tools/exit/exittool.h \
     src/tools/imgur/imguruploadertool.h \
+    src/tools/up1/up1uploadertool.h \
     src/tools/line/linetool.h \
     src/tools/marker/markertool.h \
     src/tools/move/movetool.h \
@@ -187,6 +190,7 @@ HEADERS  += src/widgets/capture/buttonhandler.h \
     src/cli/commandargument.h \
     src/utils/screenshotsaver.h \
     src/tools/imgur/imguruploader.h \
+    src/tools/up1/up1uploader.h \
     src/widgets/loadspinner.h \
     src/widgets/imagelabel.h \
     src/widgets/notificationwidget.h \
@@ -298,5 +302,6 @@ unix:!macx {
         appdata
 }
 
-# Imgur API data
+# Upload API data
 include(src/imgur.pri)
+include(src/up1.pri)

--- a/src/config/geneneralconf.cpp
+++ b/src/config/geneneralconf.cpp
@@ -38,6 +38,7 @@ GeneneralConf::GeneneralConf(QWidget *parent) : QWidget(parent) {
     initAutostart();
     initCloseAfterCapture();
     initCopyAndCloseAfterUpload();
+    initUploadHost();
 
     // this has to be at the end
     initConfingButtons();
@@ -235,5 +236,18 @@ void GeneneralConf::initCopyAndCloseAfterUpload()
 
     connect(m_copyAndCloseAfterUpload, &QCheckBox::clicked, [](bool checked) {
         ConfigHandler().setCopyAndCloseAfterUploadEnabled(checked);
+    });
+}
+
+void GeneneralConf::initUploadHost()
+{
+    m_useUp1UploadHost = new QCheckBox(tr("Use Up1 as upload host"), this);
+    ConfigHandler config;
+    m_useUp1UploadHost->setChecked(config.useUp1HostEnabled());
+    m_useUp1UploadHost->setToolTip(tr("Use Riseup instead of Imgur as the upload host"));
+    m_layout->addWidget(m_useUp1UploadHost);
+
+    connect(m_useUp1UploadHost, &QCheckBox::clicked, [](bool checked) {
+        ConfigHandler().setUseUp1HostEnabled(checked);
     });
 }

--- a/src/config/geneneralconf.h
+++ b/src/config/geneneralconf.h
@@ -49,6 +49,7 @@ private:
     QCheckBox *m_autostart;
     QCheckBox *m_closeAfterCapture;
     QCheckBox *m_copyAndCloseAfterUpload;
+    QCheckBox *m_useUp1UploadHost;
     QPushButton *m_importButton;
     QPushButton *m_exportButton;
     QPushButton *m_resetButton;
@@ -60,4 +61,5 @@ private:
     void initAutostart();
     void initCloseAfterCapture();
     void initCopyAndCloseAfterUpload();
+    void initUploadHost();
 };

--- a/src/tools/toolfactory.cpp
+++ b/src/tools/toolfactory.cpp
@@ -21,6 +21,7 @@
 #include "copy/copytool.h"
 #include "exit/exittool.h"
 #include "imgur/imguruploadertool.h"
+#include "up1/up1uploadertool.h"
 #include "line/linetool.h"
 #include "marker/markertool.h"
 #include "move/movetool.h"
@@ -35,6 +36,7 @@
 #include "redo/redotool.h"
 #include "pin/pintool.h"
 #include "text/texttool.h"
+#include "src/utils/confighandler.h"
 
 ToolFactory::ToolFactory(QObject *parent) : QObject(parent) {
 
@@ -59,7 +61,10 @@ CaptureTool* ToolFactory::CreateTool(
         tool = new ExitTool(parent);
         break;
     case CaptureButton::TYPE_IMAGEUPLOADER:
-        tool = new ImgurUploaderTool(parent);
+        if (ConfigHandler().useUp1HostEnabled())
+            tool = new Up1UploaderTool(parent);
+        else
+            tool = new ImgurUploaderTool(parent);
         break;
     case CaptureButton::TYPE_DRAWER:
         tool = new LineTool(parent);

--- a/src/tools/up1/up1uploader.cpp
+++ b/src/tools/up1/up1uploader.cpp
@@ -1,0 +1,316 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "up1uploader.h"
+#include "src/utils/filenamehandler.h"
+#include "src/utils/systemnotification.h"
+#include "src/widgets/loadspinner.h"
+#include "src/widgets/imagelabel.h"
+#include "src/widgets/notificationwidget.h"
+#include "src/utils/confighandler.h"
+#include <QApplication>
+#include <QClipboard>
+#include <QDesktopServices>
+#include <QShortcut>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QDrag>
+#include <QMimeData>
+#include <QUrlQuery>
+#include <QNetworkRequest>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+#include <openssl/rand.h>
+#include <openssl/sha.h>
+#include <openssl/evp.h>
+
+Up1Uploader::Up1Uploader(const QPixmap &capture, QWidget *parent) :
+    QWidget(parent), m_pixmap(capture)
+{
+    setWindowTitle(tr("Upload to Up1"));
+    setWindowIcon(QIcon(":img/app/flameshot.svg"));
+
+    m_spinner = new LoadSpinner(this);
+    m_spinner->setColor(ConfigHandler().uiMainColorValue());
+    m_spinner->start();
+
+    m_infoLabel = new QLabel(tr("Uploading Image"));
+
+    m_vLayout = new QVBoxLayout();
+    setLayout(m_vLayout);
+    m_vLayout->addWidget(m_spinner, 0, Qt::AlignHCenter);
+    m_vLayout->addWidget(m_infoLabel);
+
+    m_NetworkAM = new QNetworkAccessManager(this);
+    connect(m_NetworkAM, &QNetworkAccessManager::finished, this,
+            &Up1Uploader::handleReply);
+
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    upload();
+    // QTimer::singleShot(2000, this, &Up1Uploader::onUploadOk); // testing
+}
+
+void Up1Uploader::handleReply(QNetworkReply *reply) {
+    delete m_uploadForm;
+
+    m_spinner->deleteLater();
+    if (reply->error() == QNetworkReply::NoError) {
+        QJsonDocument response = QJsonDocument::fromJson(reply->readAll());
+        QJsonObject json = response.object();
+        m_imageURL.setUrl(QStringLiteral(UP1_HOST) + QStringLiteral("/#%1").arg(m_seed));
+        m_deleteImageURL.setUrl(QStringLiteral(UP1_HOST) +
+                                QStringLiteral("/del?ident=%1&delkey=%2")
+                                    .arg(m_ident, json[QStringLiteral("delkey")].toString()));
+        if (ConfigHandler().copyAndCloseAfterUploadEnabled()) {
+            QApplication::clipboard()->setText(m_imageURL.toString());
+            SystemNotification().sendMessage(QObject::tr("URL copied to clipboard."));
+            close();
+        } else {
+            onUploadOk();
+        }
+    } else {
+        m_infoLabel->setText(reply->errorString());
+    }
+    new QShortcut(Qt::Key_Escape, this, SLOT(close()));
+}
+
+void Up1Uploader::startDrag() {
+    QMimeData *mimeData = new QMimeData;
+    mimeData->setUrls(QList<QUrl> { m_imageURL });
+    mimeData->setImageData(m_pixmap);
+
+    QDrag *dragHandler = new QDrag(this);
+    dragHandler->setMimeData(mimeData);
+    dragHandler->setPixmap(m_pixmap.scaled(256, 256, Qt::KeepAspectRatioByExpanding,
+                                           Qt::SmoothTransformation));
+    dragHandler->exec();
+}
+
+bool Up1Uploader::encrypt(QByteArray* input, QByteArray* output, QString& seed, QString& ident) {
+    // N.B. We require a 64-bit tag for Up1.
+    constexpr int TAG_LENGTH = 8;
+    const int ENDIAN_TEST = 0x0001;
+
+    unsigned char entropy[32], hash[64], key[32], iv[16];
+    int length, encryptSize, ivLength;
+    EVP_CIPHER_CTX *ctx;
+    SHA512_CTX sha512;
+    bool result = false;
+    QByteArray metaBytes;
+    QString metaString;
+    ushort word;
+
+    // Metadata is prepended to the input blob prior to encryption.
+    // Must be formatted as a UTF-16 Big-Endian encoded string containing:
+    //     "{ mime: '<mime type>', name: '<file name>' }\0\0"
+    metaString = QStringLiteral("{\"mime\":\"image/png\",\"name\":\"%1.png\"}\0")
+                            .arg(FileNameHandler().parsedPattern());
+
+    metaBytes = QByteArray(reinterpret_cast<const char*>(metaString.utf16()),
+                           metaString.length() * sizeof(ushort));
+
+    // Reverse 16 bit byte order if not using a big-endian system.
+    if (*reinterpret_cast<const char *>(&ENDIAN_TEST) != 0) {
+        for (int i = 0; i < metaBytes.length(); i += 2) {
+            word = *reinterpret_cast<ushort*>(metaBytes.data() + i);
+            *reinterpret_cast<ushort*>(metaBytes.data() + i) = word << 8 | word >> 8;
+        }
+    }
+
+    input->prepend(metaBytes);
+
+    // Generate random input to convert to a seed
+    if (RAND_bytes(entropy, sizeof(entropy)) != 1)
+        goto cleanup;
+
+    // The seed can be of any length but must be in URL-encoded Base64.
+    seed = QByteArray(reinterpret_cast<const char*>(entropy), sizeof(entropy))
+                .toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
+
+    // SHA-512 of the seed in base64 produces the encryption keys.
+    SHA512_Init(&sha512);
+    SHA512_Update(&sha512, entropy, sizeof(entropy));
+    SHA512_Final(hash, &sha512);
+
+    // Key = 256 bits, IV = 128 bits
+    memcpy(key, hash, 32);
+    memcpy(iv, hash + 32, 16);
+
+    // Identity = 128 Bits (URL-Encoded Base64)
+    ident = QByteArray(reinterpret_cast<const char*>(hash + 48), 16)
+                .toBase64(QByteArray::Base64UrlEncoding | QByteArray::OmitTrailingEquals);
+
+    // Initialize AES-512 in CCM mode.
+    ctx = EVP_CIPHER_CTX_new();
+    EVP_CIPHER_CTX_init(ctx);
+    if (EVP_EncryptInit_ex(ctx, EVP_aes_256_ccm(), nullptr, nullptr, nullptr) != 1)
+        goto cleanup;
+
+    // Up1 allows by default a maximum of 50000000 bytes.
+    if (input->size() > 50000000)
+        goto cleanup;
+
+    // Calculate IV size for CCM mode.
+    if (input->size() < 0xFFFF)
+        ivLength = 13;
+    else if (input->size() < 0xFFFFFF)
+        ivLength = 12;
+    else
+        ivLength = 11;
+
+    // Set IV and tag length.
+    if (EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_IVLEN, ivLength, nullptr) != 1 ||
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_SET_TAG, TAG_LENGTH, nullptr) != 1)
+        goto cleanup;
+
+    // Set key material used.
+    if (EVP_EncryptInit_ex(ctx, nullptr, nullptr, key, iv) != 1)
+        goto cleanup;
+
+    // Retrieve the size necessary for the output buffer.
+    if (EVP_EncryptUpdate(ctx, nullptr, &length, nullptr,
+                          static_cast<int>(input->size())) != 1)
+        goto cleanup;
+
+    // Resize the buffer to the required size + tag length to append.
+    encryptSize = length;
+    output->resize(length + TAG_LENGTH);
+
+    // Encrypt the full buffer to the destination.
+    if (EVP_EncryptUpdate(ctx, reinterpret_cast<unsigned char*>(output->data()),
+                          &length,
+                          reinterpret_cast<const unsigned char*>(input->data()),
+                          static_cast<int>(input->size())) != 1)
+        goto cleanup;
+
+    // Finalize encryption and append tag.
+    if (EVP_EncryptFinal_ex(ctx, reinterpret_cast<unsigned char*>(output->data()) + encryptSize,
+                            &length) != 1)
+        goto cleanup;
+
+    EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_CCM_GET_TAG, TAG_LENGTH,
+                        reinterpret_cast<unsigned char*>(output->data()) + encryptSize);
+
+    result = true;
+
+cleanup:
+
+    EVP_CIPHER_CTX_cleanup(ctx);
+    EVP_CIPHER_CTX_free(ctx);
+
+    return result;
+}
+
+void Up1Uploader::upload() {
+    QHttpPart apiKeyPart, identPart, filePart;
+    QByteArray input, output;
+
+    QBuffer buffer(&input);
+    m_pixmap.save(&buffer, "PNG");
+
+    if (!encrypt(&input, &output, m_seed, m_ident)) {
+        m_infoLabel->setText("Encryption failed");
+        return;
+    }
+
+    m_uploadForm = new QHttpMultiPart(QHttpMultiPart::FormDataType);
+
+    apiKeyPart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"api_key\""));
+    apiKeyPart.setBody(UP1_API_KEY);
+
+    identPart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"ident\""));
+    identPart.setBody(QByteArray(m_ident.toLocal8Bit()));
+
+    filePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"file\"; filename=\"blob\""));
+    filePart.setHeader(QNetworkRequest::ContentTypeHeader, QVariant("application/octet-stream"));
+    filePart.setBody(output);
+
+    QUrl url(QStringLiteral(UP1_HOST) + QStringLiteral("/up"));
+    QNetworkRequest request(url);
+
+    m_uploadForm->append(apiKeyPart);
+    m_uploadForm->append(identPart);
+    m_uploadForm->append(filePart);
+
+    m_NetworkAM->post(request, m_uploadForm);
+}
+
+void Up1Uploader::onUploadOk() {
+    m_infoLabel->deleteLater();
+
+    m_notification = new NotificationWidget();
+    m_vLayout->addWidget(m_notification);
+
+    ImageLabel *imageLabel = new ImageLabel();
+    imageLabel->setScreenshot(m_pixmap);
+    imageLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    connect(imageLabel, &ImageLabel::dragInitiated, this, &Up1Uploader::startDrag);
+    m_vLayout->addWidget(imageLabel);
+
+    m_hLayout = new QHBoxLayout();
+    m_vLayout->addLayout(m_hLayout);
+
+    m_copyUrlButton = new QPushButton(tr("Copy URL"));
+    m_openUrlButton = new QPushButton(tr("Open URL"));
+    m_openDeleteUrlButton = new QPushButton(tr("Delete image"));
+    m_toClipboardButton = new QPushButton(tr("Image to Clipboard."));
+    m_hLayout->addWidget(m_copyUrlButton);
+    m_hLayout->addWidget(m_openUrlButton);
+    m_hLayout->addWidget(m_openDeleteUrlButton);
+    m_hLayout->addWidget(m_toClipboardButton);
+
+    connect(m_copyUrlButton, &QPushButton::clicked,
+            this, &Up1Uploader::copyURL);
+    connect(m_openUrlButton, &QPushButton::clicked,
+            this, &Up1Uploader::openURL);
+    connect(m_openDeleteUrlButton, &QPushButton::clicked,
+            this, &Up1Uploader::openDeleteURL);
+    connect(m_toClipboardButton, &QPushButton::clicked,
+            this, &Up1Uploader::copyImage);
+}
+
+void Up1Uploader::openURL() {
+    bool successful = QDesktopServices::openUrl(m_imageURL);
+    if (!successful) {
+        m_notification->showMessage(tr("Unable to open the URL."));
+    }
+}
+
+void Up1Uploader::copyURL() {
+    QApplication::clipboard()->setText(m_imageURL.toString());
+    m_notification->showMessage(tr("URL copied to clipboard."));
+}
+
+void Up1Uploader::openDeleteURL()
+{
+    bool successful = QDesktopServices::openUrl(m_deleteImageURL);
+    if (!successful) {
+        m_notification->showMessage(tr("Unable to open the URL."));
+    }
+}
+
+void Up1Uploader::copyImage() {
+    QApplication::clipboard()->setPixmap(m_pixmap);
+    m_notification->showMessage(tr("Screenshot copied to clipboard."));
+}

--- a/src/tools/up1/up1uploader.h
+++ b/src/tools/up1/up1uploader.h
@@ -1,0 +1,74 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QWidget>
+#include <QUrl>
+#include <QBuffer>
+#include <QHttpMultiPart>
+
+class QNetworkReply;
+class QNetworkAccessManager;
+class QHBoxLayout;
+class QVBoxLayout;
+class QLabel;
+class LoadSpinner;
+class QPushButton;
+class QUrl;
+class NotificationWidget;
+
+class Up1Uploader : public QWidget {
+    Q_OBJECT
+public:
+    explicit Up1Uploader(const QPixmap &capture, QWidget *parent = nullptr);
+
+private slots:
+    void handleReply(QNetworkReply *reply);
+    void startDrag();
+
+    void openURL();
+    void copyURL();
+    void openDeleteURL();
+    void copyImage();
+
+private:
+    QPixmap m_pixmap;
+    QNetworkAccessManager *m_NetworkAM;
+
+    QVBoxLayout *m_vLayout;
+    QHBoxLayout *m_hLayout;
+    // loading
+    QLabel *m_infoLabel;
+    LoadSpinner *m_spinner;
+    // uploaded
+    QPushButton *m_openUrlButton;
+    QPushButton *m_openDeleteUrlButton;
+    QPushButton *m_copyUrlButton;
+    QPushButton *m_toClipboardButton;
+    QUrl m_imageURL;
+    QUrl m_deleteImageURL;
+    NotificationWidget *m_notification;
+    // encryption
+    QString m_seed;
+    QString m_ident;
+    QHttpMultiPart *m_uploadForm;
+
+    bool encrypt(QByteArray* input, QByteArray* output, QString& seed, QString& ident);
+    void upload();
+    void onUploadOk();
+};

--- a/src/tools/up1/up1uploadertool.cpp
+++ b/src/tools/up1/up1uploadertool.cpp
@@ -1,0 +1,58 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "up1uploadertool.h"
+#include "up1uploader.h"
+#include <QPainter>
+
+Up1UploaderTool::Up1UploaderTool(QObject *parent) : AbstractActionTool(parent) {
+
+}
+
+bool Up1UploaderTool::closeOnButtonPressed() const {
+    return true;
+}
+
+QIcon Up1UploaderTool::icon(const QColor &background, bool inEditor) const {
+    Q_UNUSED(inEditor);
+    return QIcon(iconPath(background) + "cloud-upload.svg");
+}
+QString Up1UploaderTool::name() const {
+    return tr("Image Uploader");
+}
+
+QString Up1UploaderTool::nameID() {
+    return QLatin1String("");
+}
+
+QString Up1UploaderTool::description() const {
+    return tr("Upload the selection to Up1");
+}
+
+QWidget* Up1UploaderTool::widget() {
+    return new Up1Uploader(capture);
+}
+
+CaptureTool* Up1UploaderTool::copy(QObject *parent) {
+    return new Up1UploaderTool(parent);
+}
+
+void Up1UploaderTool::pressed(const CaptureContext &context) {
+    capture = context.selectedScreenshotArea();
+    emit requestAction(REQ_CAPTURE_DONE_OK);
+    emit requestAction(REQ_ADD_EXTERNAL_WIDGETS);
+}

--- a/src/tools/up1/up1uploadertool.h
+++ b/src/tools/up1/up1uploadertool.h
@@ -1,0 +1,43 @@
+// Copyright(c) 2017-2019 Alejandro Sirgo Rica & Contributors
+//
+// This file is part of Flameshot.
+//
+//     Flameshot is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//
+//     Flameshot is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//
+//     You should have received a copy of the GNU General Public License
+//     along with Flameshot.  If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include "src/tools/abstractactiontool.h"
+
+class Up1UploaderTool : public AbstractActionTool {
+    Q_OBJECT
+public:
+    explicit Up1UploaderTool(QObject *parent = nullptr);
+
+    bool closeOnButtonPressed() const;
+
+    QIcon icon(const QColor &background, bool inEditor) const override;
+    QString name() const override;
+    static QString nameID();
+    QString description() const override;
+
+    QWidget* widget() override;
+
+    CaptureTool* copy(QObject *parent = nullptr) override;
+
+public slots:
+    void pressed(const CaptureContext &context) override;
+
+private:
+    QPixmap capture;
+};

--- a/src/up1.pri
+++ b/src/up1.pri
@@ -2,11 +2,11 @@
 # this variable to qmake
 
 isEmpty(UP1_HOST) {
-    UP1_HOST = "https://share.riseup.net"
+    UP1_HOST = "https://pastebin.synalabs.hosting"
 }
 
 isEmpty(UP1_API_KEY) {
-    UP1_API_KEY = "59Mnk5nY6eCn4bi9GvfOXhMH54E7Bh6EMJXtyJfs"
+    UP1_API_KEY = "4034a170b4517897238b58ecbe902dee187bf890"
 }
 
 DEFINES += UP1_HOST=\\\"$${UP1_HOST}\\\"

--- a/src/up1.pri
+++ b/src/up1.pri
@@ -1,0 +1,13 @@
+# Use default Up1 host and API key if user did not pass
+# this variable to qmake
+
+isEmpty(UP1_HOST) {
+    UP1_HOST = "https://share.riseup.net"
+}
+
+isEmpty(UP1_API_KEY) {
+    UP1_API_KEY = "59Mnk5nY6eCn4bi9GvfOXhMH54E7Bh6EMJXtyJfs"
+}
+
+DEFINES += UP1_HOST=\\\"$${UP1_HOST}\\\"
+DEFINES += UP1_API_KEY=\\\"$${UP1_API_KEY}\\\"

--- a/src/utils/confighandler.cpp
+++ b/src/utils/confighandler.cpp
@@ -333,6 +333,14 @@ void ConfigHandler::setCopyAndCloseAfterUploadEnabled(const bool value) {
     m_settings.setValue(QStringLiteral("copyAndCloseAfterUpload"), value);
 }
 
+bool ConfigHandler::useUp1HostEnabled() {
+    return m_settings.value(QStringLiteral("useUp1Host")).toBool();
+}
+
+void ConfigHandler::setUseUp1HostEnabled(const bool value) {
+    m_settings.setValue(QStringLiteral("useUp1Host"), value);
+}
+
 void ConfigHandler::setDefaults() {
     m_settings.clear();
 }

--- a/src/utils/confighandler.h
+++ b/src/utils/confighandler.h
@@ -74,6 +74,8 @@ public:
     bool copyAndCloseAfterUploadEnabled();
     void setCopyAndCloseAfterUploadEnabled(const bool);
 
+    bool useUp1HostEnabled();
+    void setUseUp1HostEnabled(const bool);
 
     void setDefaults();
     void setAllTheButtons();


### PR DESCRIPTION
This is a C&P request of the original one I submitted to [here](https://github.com/lupoDharkael/flameshot/pull/669). Since that project seems dead now I'd love if this could be committed here. 

Changes from the original pull request switches from `riseup.net` to `synalabs.hosting`.

> Adds encrypted image uploads using the Up1 implementation. Images are encrypted using AES-256 in CCM mode from a (securely) generated random key prior to being uploaded.
> 
> For this, Appveyor's Qt version was upgraded to v5.12.5 from v5.9 and OpenSSL is now explicitly linked with v1.1.1d over the older and vulnerable v1.0.2k. In addition, x86 building was disabled for Appveyor due to MSVC only being available on the much older v5.9 (building is still supported for x86 but requires
MSVC x86 build tools for Qt v5.12)
> 
> The actual Up1 specification may be viewed at Uploads/Up1 but by default, it is configured to use Riseup's service at share.riseup.net. Any Up1 compatible service may be used by configuring the build variables UP1_HOST and UP1_API_KEY.
> 
> To configure which image host to upload to, a new toggle has been added to the [General] configuration for switching between Imgur and Up1 (Riseup).