### PR TITLE
Implement UUID Identifier

### DIFF
--- a/src/config/strftimechooserwidget.cpp
+++ b/src/config/strftimechooserwidget.cpp
@@ -65,4 +65,5 @@ QMap<QString, QString> StrftimeChooserWidget::m_buttonData {
     { QT_TR_NOOP("Second (00-59)"),         "%S"},
     { QT_TR_NOOP("Full Date (%m/%d/%y)"),   "%D"},
     { QT_TR_NOOP("Full Date (%Y-%m-%d)"),   "%F"},
+    { QT_TR_NOOP("Random UUID (%%U)"),     "%%U"},
 };

--- a/src/utils/filenamehandler.cpp
+++ b/src/utils/filenamehandler.cpp
@@ -21,6 +21,7 @@
 #include <locale>
 #include <QStandardPaths>
 #include <QDir>
+#include <QUuid>
 
 FileNameHandler::FileNameHandler(QObject *parent) : QObject(parent) {
     std::locale::global(std::locale(""));
@@ -46,6 +47,9 @@ QString FileNameHandler::parseFilename(const QString &name) {
 
     // add the parsed pattern in a correct format for the filesystem
     res = res.replace(QLatin1String("/"), QStringLiteral("⁄")).replace(QLatin1String(":"), QLatin1String("-"));
+
+    // add random uuid if required
+    res = res.replace(QLatin1String("%U"), QUuid::createUuid().toString(QUuid::WithoutBraces));
     return res;
 }
 


### PR DESCRIPTION
This allows users to select a randomly generated UUID for
the file names rather than a date-based name.

Particularly useful for when uploading to image hosts and
not wanting to reveal the date or time an image was taken
prior to uploading.