### PR TITLE
Bumped minimum Cmake version to fix build issues on Cmake 4.0

### DIFF
--- a/external/Qt-Color-Widgets/CMakeLists.txt
+++ b/external/Qt-Color-Widgets/CMakeLists.txt
@@ -14,10 +14,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
-if ( ${CMAKE_VERSION} VERSION_GREATER "3.12.0")
-    cmake_policy(SET CMP0077 NEW)
-endif()
+cmake_minimum_required (VERSION 3.22 FATAL_ERROR)
+cmake_policy(SET CMP0077 NEW)
 
 set(COLORWIDGET_PROJECT_NAME QtColorWidgets)
 project(${COLORWIDGET_PROJECT_NAME} CXX)

--- a/external/Qt-Color-Widgets/color_widgets_designer_plugin/CMakeLists.txt
+++ b/external/Qt-Color-Widgets/color_widgets_designer_plugin/CMakeLists.txt
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Color Widgets.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.22 FATAL_ERROR)
 
 project(QtColorWidgetsPlugin CXX)
 

--- a/external/singleapplication/CMakeLists.txt
+++ b/external/singleapplication/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.0)
+cmake_minimum_required(VERSION 3.22.0)
 
 project(SingleApplication LANGUAGES CXX)
 


### PR DESCRIPTION
3.22 was chosen since that is the version on Ubuntu 22.04